### PR TITLE
Add colorful login page with elephant mascot and guest option

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { Routes, Route, Link } from 'react-router-dom'
+import { Routes, Route, Link, useLocation } from 'react-router-dom'
 import Home from './pages/Home.jsx'
+import Login from './pages/Login.jsx'
 import District from './pages/District.jsx'
 import QuestBoard from './pages/QuestBoard.jsx'
 import Quest from './pages/Quest.jsx'
@@ -8,18 +9,23 @@ import Stampbook from './pages/Stampbook.jsx'
 import Chatbot from './pages/Chatbot.jsx'
 
 export default function App() {
+  const location = useLocation()
+
   return (
     <div className="app">
-      <nav className="nav">
-        <Link to="/" className="logo">🐘 JumBah</Link>
-        <div className="nav-links">
-          <Link to="/stampbook">Stampbook</Link>
-          <Link to="/chat">Chat</Link>
-        </div>
-      </nav>
+      {location.pathname !== '/' && (
+        <nav className="nav">
+          <Link to="/home" className="logo">🐘 JumBah</Link>
+          <div className="nav-links">
+            <Link to="/stampbook">Stampbook</Link>
+            <Link to="/chat">Chat</Link>
+          </div>
+        </nav>
+      )}
 
       <Routes>
-        <Route path="/" element={<Home />} />
+        <Route path="/" element={<Login />} />
+        <Route path="/home" element={<Home />} />
         <Route path="/district/:id" element={<District />} />
         <Route path="/district/:id/quests" element={<QuestBoard />} />
         <Route path="/quest/:id" element={<Quest />} />

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { useNavigate } from 'react-router-dom'
+
+export default function Login() {
+  const navigate = useNavigate()
+  const handleGuest = () => navigate('/home')
+
+  return (
+    <div className="login-page">
+      <div className="login-card">
+        <div className="elephant">🐘</div>
+        <h1>Welcome to JumBah!</h1>
+        <p>Log in to start your adventure or continue as a guest.</p>
+        <input type="email" placeholder="Email" />
+        <input type="password" placeholder="Password" />
+        <button className="btn" style={{width:'100%', marginTop:8}}>Log In</button>
+        <button className="btn secondary" style={{width:'100%', marginTop:8}} onClick={handleGuest}>Continue as Guest</button>
+      </div>
+    </div>
+  )
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -18,3 +18,8 @@ a { color: inherit; text-decoration: none; }
 .qr-box { border:2px dashed #94a3b8; border-radius:12px; padding:12px; display:flex; justify-content:center; align-items:center; min-height:240px; background:#f1f5f9; }
 .footer-cta { text-align:center; margin-top:24px; }
 .small { font-size:12px; color:#475569; }
+
+.login-page { display:flex; justify-content:center; align-items:center; min-height:100vh; background:linear-gradient(135deg, #a855f7, #0ea5e9); padding:16px; }
+.login-card { background:rgba(255,255,255,0.9); padding:24px; border-radius:16px; max-width:320px; width:100%; text-align:center; color:#0f172a; }
+.login-card .elephant { font-size:64px; margin-bottom:8px; }
+.login-card input { width:100%; padding:10px; margin:8px 0; border:1px solid #e2e8f0; border-radius:8px; }


### PR DESCRIPTION
## Summary
- Introduce new login page featuring elephant mascot and guest access
- Route home content under `/home` and show nav only after login
- Style login screen with vibrant gradient and modern card layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found, dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b38723cc832f8d4ec50b3d7b3bf2